### PR TITLE
Add check for existence of required binaries

### DIFF
--- a/installtelmac.sh
+++ b/installtelmac.sh
@@ -6,6 +6,23 @@ contenturl=https://cdn.teleport.dev
 deletewithoutconfirming=false
 checksum=true
 
+# function to check whether a named program exists
+check_exists() {
+    NAME=$1
+    if type "${NAME}" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+for BINARY in curl jq shasum wget; do
+    if ! check_exists ${BINARY}; then
+        echo "${BINARY} must be installed, it was not found"
+        exit 1
+    fi
+done
+
 while getopts p:v:e:d:c: flag
 do
     case "${flag}" in


### PR DESCRIPTION
Fixes an error when `jq` is not installed:

```
~/git » installtelmac.sh -p teleport.example.com
Proxy is teleport.example.com
/usr/local/bin/installtelmac.sh: line 26: jq: command not found
Installing to match teleport.example.com version
Validating files for install
Confirmed https://cdn.teleport.dev/teleport-ent-.pkg.sha256. Used for confirming Teleport checksum.
Confirmed https://cdn.teleport.dev/tsh-.pkg.sha256. Used for confirming tsh checksum.
https://cdn.teleport.dev/teleport-ent-.pkg unavailable. Teleport package. Check version
```